### PR TITLE
Untitled

### DIFF
--- a/lib/puffer/inputs/association.rb
+++ b/lib/puffer/inputs/association.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 module Puffer
   module Inputs
     class Association < Puffer::Inputs::Base


### PR DESCRIPTION
Under ruby 1.9.x without this line editing and testing with RSpec doesn't work.
