### PR TITLE
Enforce using resource id instead of resource

### DIFF
--- a/app/controllers/puffer/sessions_base.rb
+++ b/app/controllers/puffer/sessions_base.rb
@@ -7,7 +7,7 @@ class Puffer::SessionsBase < ApplicationController
 
   before_filter :require_puffer_user, :only => :destroy
 
-  define_fieldset :create
+  define_fieldset :create, :fallbacks => :form
 
   layout 'puffer_sessions'
 

--- a/lib/puffer/resource/routing.rb
+++ b/lib/puffer/resource/routing.rb
@@ -11,7 +11,7 @@ module Puffer
 
       def member_method routing_type, *args
         options = args.extract_options!
-        send url_method_name(routing_type, singular, options.delete(:action)), *url_arguments(args.first || member_id), options
+        send url_method_name(routing_type, singular, options.delete(:action)), *url_arguments(user_resource_id(args.first) || member_id), options
       end
 
       def new_method routing_type, options = {}
@@ -41,6 +41,14 @@ module Puffer
 
       def default_url_options *args
         Puffer::Base.default_url_options(*args)
+      end
+
+      def user_resource_id(resource)
+        if resource and resource.respond_to?(:id)
+          resource.id
+        else
+          resource
+        end
       end
 
     end

--- a/lib/puffer/resource/routing.rb
+++ b/lib/puffer/resource/routing.rb
@@ -11,7 +11,7 @@ module Puffer
 
       def member_method routing_type, *args
         options = args.extract_options!
-        send url_method_name(routing_type, singular, options.delete(:action)), *url_arguments(user_resource_id(args.first) || member_id), options
+        send url_method_name(routing_type, singular, options.delete(:action)), *url_arguments(use_resource_id(args.first) || member_id), options
       end
 
       def new_method routing_type, options = {}
@@ -43,7 +43,7 @@ module Puffer
         Puffer::Base.default_url_options(*args)
       end
 
-      def user_resource_id(resource)
+      def use_resource_id(resource)
         if resource and resource.respond_to?(:id)
           resource.id
         else


### PR DESCRIPTION
Helps when you are over-writng to_param (seo)   #24
